### PR TITLE
Fix yaml and meta errors, create final branch

### DIFF
--- a/Assets/Scenes.meta
+++ b/Assets/Scenes.meta
@@ -3,6 +3,6 @@ guid: b2c3d4e5f6789012345678901234568
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Assets/Scenes/TicTacToeGame.unity.meta
+++ b/Assets/Scenes/TicTacToeGame.unity.meta
@@ -2,6 +2,6 @@ fileFormatVersion: 2
 guid: 4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s
 DefaultImporter:
   externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -3,6 +3,6 @@ guid: a1b2c3d4e5f6789012345678901234567
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Assets/Scripts/SoundManager.cs.meta
+++ b/Assets/Scripts/SoundManager.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Assets/Scripts/TicTacToeGame.cs.meta
+++ b/Assets/Scripts/TicTacToeGame.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""

--- a/Assets/Scripts/UIManager.cs.meta
+++ b/Assets/Scripts/UIManager.cs.meta
@@ -6,6 +6,6 @@ MonoImporter:
   defaultReferences: []
   executionOrder: 0
   icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant:
+  userData: ""
+  assetBundleName: ""
+  assetBundleVariant: ""


### PR DESCRIPTION
Fix YAML parsing errors in Unity .meta files by correctly formatting empty string values.

Previously, empty values like `userData: ` were causing YAML parsing failures and invalid GUID errors in Unity. This PR explicitly sets these to `userData: ""` to resolve the issues.